### PR TITLE
CONTRIB-5545 Use absolute path for require[_once]

### DIFF
--- a/connect_class_dom.php
+++ b/connect_class_dom.php
@@ -8,7 +8,7 @@
  */
 
 
-require_once('connect_class.php');
+require_once($CFG->dirroot . '/mod/adobeconnect/connect_class.php');
 
 class connect_class_dom extends connect_class {
 

--- a/lib.php
+++ b/lib.php
@@ -6,7 +6,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once('locallib.php');
+require_once($CFG->dirroot . '/mod/adobeconnect/locallib.php');
 
 /**
  * Library of functions and constants for module adobeconnect

--- a/locallib.php
+++ b/locallib.php
@@ -7,8 +7,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once('connect_class.php');
-require_once('connect_class_dom.php');
+require_once($CFG->dirroot . '/mod/adobeconnect/connect_class.php');
+require_once($CFG->dirroot . '/mod/adobeconnect/connect_class_dom.php');
 
 define('ADOBE_VIEW_ROLE', 'view');
 define('ADOBE_HOST_ROLE', 'host');

--- a/participants.php
+++ b/participants.php
@@ -24,7 +24,7 @@
 
 require_once(dirname(__FILE__) . '/../../config.php');
 require_once($CFG->dirroot . '/' . $CFG->admin . '/roles/lib.php');
-require_once('locallib.php');
+require_once($CFG->dirroot . '/mod/adobeconnect/locallib.php');
 
 define("MAX_USERS_TO_LIST_PER_ROLE", 10);
 


### PR DESCRIPTION
See CONTRIB-5545 for an example of where this was a problem in core.
Should be safe to backport to a majority of branches but I haven't double-checked.
