### PR TITLE
renderer: add a check if the current user can view/add meeting participants

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -201,14 +201,16 @@ class mod_adobeconnect_renderer extends plugin_renderer_base {
         $html .= html_writer::empty_tag('input', $param);
         $html .= html_writer::end_tag('div');
 
-        $param = array('class' => 'aconbtnroles');
-        $html .= html_writer::start_tag('div', $param);
-        $param = array('type'=>'submit',
-                       'value'=>get_string('selectparticipants','adobeconnect'),
-                       'name'=>'participants',
-                       );
-        $html .= html_writer::empty_tag('input', $param);
-        $html .= html_writer::end_tag('div');
+        if ($meetingdetail->participants) {
+            $param = array('class' => 'aconbtnroles');
+            $html .= html_writer::start_tag('div', $param);
+            $param = array('type'=>'submit',
+                           'value'=>get_string('selectparticipants','adobeconnect'),
+                           'name'=>'participants',
+                           );
+            $html .= html_writer::empty_tag('input', $param);
+            $html .= html_writer::end_tag('div');
+        }
 
         $html .= html_writer::end_tag('div');
 


### PR DESCRIPTION
Hi, 

We noticed that the capability of the user to assign/view participants wasn't being adhered to on the meeting detail page and the button was being rendered to users who should not see it. I have added in the check for this capability to ensure it doesn't display.

Regards,
Stacey
