### PR TITLE
Remove requirement for lib/eventslib.php

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -40,8 +40,6 @@ require_once('locallib.php');
 
 $adobeconnect_EXAMPLE_CONSTANT = 42;
 
-/** Include eventslib.php */
-require_once($CFG->libdir.'/eventslib.php');
 /** Include calendar/lib.php */
 require_once($CFG->dirroot.'/calendar/lib.php');
 


### PR DESCRIPTION
lib/eventslib.php was removed from Moodle 3.6 as announced in https://github.com/moodle/moodle/blob/master/lib/upgrade.txt#L95 but mod_adobeconnect still requires it on https://github.com/remotelearner/moodle-mod_adobeconnect/blob/MOODLE_34_STABLE/lib.php#L44.

However, this requirement seems to be historic. At least none of the former functions in lib/eventslib.php are called directly by mod_adobeconnect.

That's why it should be safe to remove this requirement to make this plugin work on Moodle 3.6 again.

--------------

I am submitting this patch against your existing 3.4 branch. However, you will most probably want to merge it into a new 3.6 branch only.